### PR TITLE
Topic/fully qualified paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For a list of the schematics that are available by default, see [here](https://g
 
 ### Creating your own schematics
 
-You can easily create your own schematics through use of `fz generate schematic <path/to/schematics/folder/schematic_name>`. This will create a new, blank schematic with the necessary files, and you can then render this new schematic with `fz generate <path/to/schematics/folder/schematic_name> [args]`
+You can easily create your own schematics through use of `fz generate schematic path/to/schematics/schematic_name`. This will create a new, blank schematic with the necessary files, and you can then render this new schematic with `fz generate path/to/schematics/:schematic_name [args]`  -- note the `:` used to separate the schematic name when invoking. For simplicity, you can optionally drop the trailing `schematics/` from the path as this folder is always required by the convention in `flaskerize` (e.g. `fz generate /path/to:schematic_name [args]`)
 
 Custom arguments, run functionality, and functions can then be provided in schema.json, run.py, and custom_functions.py, respectively. See the other sections of this README for specific details on each of these.
 

--- a/changelog.md
+++ b/changelog.md
@@ -48,3 +48,7 @@
 0.10.0
 
 - Internal refactor to use PyFilesystem with a two-step staging of file changes and modifications using an in-memory buffer followed by a commit step upon success at which time the changes are actually made to the file system, unless on a dry run
+
+0.11.0
+
+- Allow user to provide full path to schematics directory or the root level above it, such as for a library

--- a/flaskerize/generate_test.py
+++ b/flaskerize/generate_test.py
@@ -142,12 +142,13 @@ def test__generate_with_adds_extension(tmp_path):
     assert path.isfile(output_name + ".py")
 
 
-def test_(tmp_path):
+def test_full_schematic_path(tmp_path):
     import os
 
     from flaskerize.parser import Flaskerize
 
-    schematic_path = os.path.join(tmp_path, "schematics/doodad/")
+    schematic_dir = os.path.join(tmp_path, "schematics")
+    schematic_path = os.path.join(schematic_dir, "doodad/")
     schema_filename = os.path.join(schematic_path, "schema.json")
     schematic_files_path = os.path.join(schematic_path, "files/")
     template_filename = os.path.join(schematic_files_path, "test_file.txt.template")
@@ -164,5 +165,30 @@ def test_(tmp_path):
     fz = Flaskerize(
         f"fz generate doodad name --schematic-path {schematic_path} --from-dir {outdir}".split()
     )
+
+    assert os.path.isfile(os.path.join(tmp_path, "test/test_file.txt"))
+
+
+def test_with_full_path(tmp_path):
+    import os
+
+    from flaskerize.parser import Flaskerize
+
+    schematic_dir = os.path.join(tmp_path, "schematics")
+    schematic_path = os.path.join(schematic_dir, "doodad/")
+    schema_filename = os.path.join(schematic_path, "schema.json")
+    schematic_files_path = os.path.join(schematic_path, "files/")
+    template_filename = os.path.join(schematic_files_path, "test_file.txt.template")
+    os.makedirs(schematic_path)
+    os.makedirs(schematic_files_path)
+    SCHEMA_CONTENTS = """{"options": []}"""
+    with open(schema_filename, "w") as fid:
+        fid.write(SCHEMA_CONTENTS)
+    CONTENTS = "{{ secret }}"
+    with open(template_filename, "w") as fid:
+        fid.write(CONTENTS)
+
+    outdir = os.path.join(tmp_path, "test/")
+    fz = Flaskerize(f"fz generate {tmp_path}:doodad name --from-dir {outdir}".split())
 
     assert os.path.isfile(os.path.join(tmp_path, "test/test_file.txt"))

--- a/flaskerize/generate_test.py
+++ b/flaskerize/generate_test.py
@@ -142,33 +142,6 @@ def test__generate_with_adds_extension(tmp_path):
     assert path.isfile(output_name + ".py")
 
 
-def test_full_schematic_path(tmp_path):
-    import os
-
-    from flaskerize.parser import Flaskerize
-
-    schematic_dir = os.path.join(tmp_path, "schematics")
-    schematic_path = os.path.join(schematic_dir, "doodad/")
-    schema_filename = os.path.join(schematic_path, "schema.json")
-    schematic_files_path = os.path.join(schematic_path, "files/")
-    template_filename = os.path.join(schematic_files_path, "test_file.txt.template")
-    os.makedirs(schematic_path)
-    os.makedirs(schematic_files_path)
-    SCHEMA_CONTENTS = """{"options": []}"""
-    with open(schema_filename, "w") as fid:
-        fid.write(SCHEMA_CONTENTS)
-    CONTENTS = "{{ secret }}"
-    with open(template_filename, "w") as fid:
-        fid.write(CONTENTS)
-
-    outdir = os.path.join(tmp_path, "test/")
-    fz = Flaskerize(
-        f"fz generate doodad name --schematic-path {schematic_path} --from-dir {outdir}".split()
-    )
-
-    assert os.path.isfile(os.path.join(tmp_path, "test/test_file.txt"))
-
-
 def test_with_full_path(tmp_path):
     import os
 

--- a/flaskerize/parser.py
+++ b/flaskerize/parser.py
@@ -199,7 +199,11 @@ class Flaskerize(object):
         return spec
 
     def _check_get_schematic_dirname(self, pkg_path: str) -> str:
-        schematic_dirname = path.join(pkg_path, "schematics")
+        if os.path.split(pkg_path)[-1] != "schematics":
+            # Allow user to provide path to either root level or to schematics/ itself
+            schematic_dirname = path.join(pkg_path, "schematics")
+        else:
+            schematic_dirname = pkg_path
         if not path.isdir(schematic_dirname):
             raise ValueError(
                 f"Unable to locate directory 'schematics/' in path {schematic_dirname}"

--- a/flaskerize/parser.py
+++ b/flaskerize/parser.py
@@ -165,28 +165,14 @@ class Flaskerize(object):
         from_dir = parsed.from_dir
         render_dirname, name = path.split(root_name)
 
-        # TODO: cleanup logic for when full schematic path is passed versus providing a
-        # package name. Perhaps just use the same param but check if it is pathlike and
-        # assume package-like if it doesn't exist
-        if parsed.schematic_path:
-            self._check_render_schematic(
-                schematic,
-                name=name,
-                render_dirname=render_dirname,
-                src_path=from_dir,
-                dry_run=dry_run,
-                full_schematic_path=parsed.schematic_path,
-                args=rest,
-            )
-        else:
-            self._check_render_schematic(
-                schematic,
-                render_dirname=render_dirname,
-                src_path=from_dir,
-                name=name,
-                dry_run=dry_run,
-                args=rest,
-            )
+        self._check_render_schematic(
+            schematic,
+            render_dirname=render_dirname,
+            src_path=from_dir,
+            name=name,
+            dry_run=dry_run,
+            args=rest,
+        )
 
     def _split_pkg_schematic(
         self, pkg_schematic: str, delim: str = ":"
@@ -246,7 +232,6 @@ class Flaskerize(object):
         src_path: str,
         name: str,
         args: List[Any],
-        full_schematic_path: Optional[str] = None,
         dry_run: bool = False,
         delim: str = ":",
     ) -> None:
@@ -254,19 +239,14 @@ class Flaskerize(object):
 
         from flaskerize import generate
 
-        if full_schematic_path is not None:
-            schematic_path = full_schematic_path
-        else:
-            pkg_or_path, schematic = self._split_pkg_schematic(
-                pkg_schematic, delim=delim
-            )
+        pkg_or_path, schematic = self._split_pkg_schematic(pkg_schematic, delim=delim)
 
-            if _is_pathlike(pkg_or_path):
-                pkg_path = pkg_or_path
-            else:
-                module_spec = self._check_validate_package(pkg_or_path)
-                pkg_path = self._get_pkg_path_from_spec(module_spec)
-            schematic_path = self._check_get_schematic(schematic, pkg_path)
+        if _is_pathlike(pkg_or_path):
+            pkg_path = pkg_or_path
+        else:
+            module_spec = self._check_validate_package(pkg_or_path)
+            pkg_path = self._get_pkg_path_from_spec(module_spec)
+        schematic_path = self._check_get_schematic(schematic, pkg_path)
         self.render_schematic(
             schematic_path,
             render_dirname=render_dirname,

--- a/flaskerize/parser_test.py
+++ b/flaskerize/parser_test.py
@@ -219,27 +219,3 @@ def test__split_pkg_schematic_only_grabs_last_delim(test_flaskerize_args, tmp_pa
     pkg, schematic = fz._split_pkg_schematic("path/to/:my:/schematic:schematic")
     assert pkg == "path/to/:my:/schematic"
     assert schematic == "schematic"
-
-
-def test__check_render_schematic(test_flaskerize_args, tmp_path):
-    tmp_app_path = os.path.join(tmp_path)
-    fz = Flaskerize(test_flaskerize_args)
-    mock = fz.render_schematic = MagicMock()
-    result = fz._check_render_schematic(
-        pkg_schematic="test",
-        render_dirname="test",
-        src_path=str(tmp_path),
-        name="test",
-        args=[],
-        full_schematic_path="some_path",
-        dry_run=True,
-    )
-    mock.assert_called_with(
-        "some_path",
-        render_dirname="test",
-        src_path=str(tmp_path),
-        name="test",
-        dry_run=True,
-        args=[],
-    )
-

--- a/flaskerize/parser_test.py
+++ b/flaskerize/parser_test.py
@@ -197,6 +197,30 @@ def test__split_pkg_schematic(test_flaskerize_args, tmp_path):
         pkg, schematic = fz._split_pkg_schematic(":schematic")
 
 
+def test__split_pkg_schematic_works_with_pkg(test_flaskerize_args, tmp_path):
+    tmp_app_path = os.path.join(tmp_path, "test.py")
+    fz = Flaskerize(test_flaskerize_args)
+    pkg, schematic = fz._split_pkg_schematic("my_pkg:schematic")
+    assert pkg == "my_pkg"
+    assert schematic == "schematic"
+
+
+def test__split_pkg_schematic_works_with_full_path(test_flaskerize_args, tmp_path):
+    tmp_app_path = os.path.join(tmp_path, "test.py")
+    fz = Flaskerize(test_flaskerize_args)
+    pkg, schematic = fz._split_pkg_schematic("path/to/schematic:schematic")
+    assert pkg == "path/to/schematic"
+    assert schematic == "schematic"
+
+
+def test__split_pkg_schematic_only_grabs_last_delim(test_flaskerize_args, tmp_path):
+    tmp_app_path = os.path.join(tmp_path, "test.py")
+    fz = Flaskerize(test_flaskerize_args)
+    pkg, schematic = fz._split_pkg_schematic("path/to/:my:/schematic:schematic")
+    assert pkg == "path/to/:my:/schematic"
+    assert schematic == "schematic"
+
+
 def test__check_render_schematic(test_flaskerize_args, tmp_path):
     tmp_app_path = os.path.join(tmp_path)
     fz = Flaskerize(test_flaskerize_args)

--- a/flaskerize/parser_test.py
+++ b/flaskerize/parser_test.py
@@ -26,14 +26,6 @@ def test_flaskerize_generate():
     assert not os.path.isfile("should_not_create.py")
 
 
-# @patch.dict("flaskerize.generate.a", {"blueprint": lambda params: None})
-# def test_bundle_calls_attach(tmp_path):
-#     with patch.object(Flaskerize, "attach") as mock:
-#         fz = Flaskerize("fz bundle --from test/build/ --to app:create_app".split())
-
-#         mock.assert_called_once()
-
-
 @patch.dict("flaskerize.generate.a", {"blueprint": lambda params: None})
 def test_bundle_calls_attach(tmp_path):
     with patch("flaskerize.attach.attach") as mock:

--- a/flaskerize/parser_test.py
+++ b/flaskerize/parser_test.py
@@ -179,6 +179,19 @@ def test__check_get_schematic_dirname(test_flaskerize_args, tmp_path):
         fz._check_get_schematic_dirname(tmp_pkg_path)
 
 
+def test__check_get_schematic_dirname_doesnt_append_if_already_schematics(
+    test_flaskerize_args, tmp_path
+):
+    tmp_pkg_path = os.path.join(tmp_path, "some/pkg/schematics")
+    os.makedirs(tmp_pkg_path)
+    fz = Flaskerize(test_flaskerize_args)
+
+    dirname = fz._check_get_schematic_dirname(tmp_pkg_path)
+
+    expected = tmp_pkg_path
+    assert dirname == expected
+
+
 def test__check_get_schematic_path(test_flaskerize_args, tmp_path):
     tmp_schematic_path = os.path.join(tmp_path, "some/pkg")
     os.makedirs(tmp_schematic_path)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="flaskerize",
-    version="0.10.0",
+    version="0.11.0",
     description="Python CLI build/dev tool for templated code generation and project modification. Think Angular schematics for Python.",
     author="AJ Pryor",
     author_email="apryor6@gmail.com",


### PR DESCRIPTION
This implements #21 with support for fully-qualified paths to schematics. This enables usage of user-created schematics without requiring that they be implemented in a Python package (which is, of course, also still an option).